### PR TITLE
Fixed inconsistencies in example #4

### DIFF
--- a/notebooks/raiderStats/raiderStats_tutorial.ipynb
+++ b/notebooks/raiderStats/raiderStats_tutorial.ipynb
@@ -586,6 +586,27 @@
     "hidden": true
    },
    "source": [
+    "#### Save variogram figures per time-slice (**`--variogram_per_timeslice`**)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "hidden": true
+   },
+   "source": [
+    "Specify **`--variogram_per_timeslice`** to generate variogram plots per gridded station AND time-slice.\n",
+    "\n",
+    "If option not toggled, then variogram plots are only generated per gridded station and spanning entire time-span."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "heading_collapsed": true,
+    "hidden": true
+   },
+   "source": [
     "### 7. Optional controls for plotting\n",
     "<a id='overview_7'></a>"
    ]
@@ -1069,7 +1090,7 @@
     "hidden": true
    },
    "source": [
-    "Produce plot illustrating gridded mean tropospheric zenith delay, superimposed with individual station locations.\n",
+    "Produce plots illustrating empirical/experimental variogram fits per gridded station and time-slice (**`-variogram_per_timeslice`**) and also spanning the entire time-span. Plots of gridded station experimental variogram-derived sill and range values also generated.\n",
     "\n",
     "Additionally, subset data in time for spring. I.e. **`'03-21 06-21'`**\n",
     "\n",
@@ -1083,7 +1104,7 @@
    "outputs": [],
    "source": [
     "!rm -rf maps\n",
-    "!raiderStats.py --file products/CombinedGPS_ztd.csv -w maps -b '36 40 -124 -119' -ti '2018-01-01 2019-12-31' --seasonalinterval '03-21 06-21' -variogramplot -verbose --cpus all"
+    "!raiderStats.py --file products/CombinedGPS_ztd.csv -w maps -b '36 40 -124 -119' -ti '2018-01-01 2019-12-31' --seasonalinterval '03-21 06-21' -variogramplot -variogram_per_timeslice --cpus all"
    ]
   },
   {
@@ -1110,7 +1131,9 @@
     "hidden": true
    },
    "source": [
-    "There are several subdirectories corresponding to each grid-cell that each contain empirical and experimental variograms generated for each time-slice (e.g. **`grid6_timeslice20180321_justEMPvariogram.eps `** and **`grid6_timeslice20180321_justEXPvariogram.eps `**, respectively) and across the entire sampled time period (**`grid6_timeslice20180321–20190621_justEMPvariogram.eps `** and **`grid6_timeslice20180321–20190621_justEXPvariogram.epss `**, respectively)"
+    "There are several subdirectories corresponding to each grid-cell that each contain empirical and experimental variograms generated for each time-slice (e.g. **`grid6_timeslice20180321_justEMPvariogram.eps `** and **`grid6_timeslice20180321_justEXPvariogram.eps `**, respectively) and across the entire sampled time period (**`grid6_timeslice20180321–20190621_justEMPvariogram.eps `** and **`grid6_timeslice20180321–20190621_justEXPvariogram.epss `**, respectively).\n",
+    "\n",
+    "Recall that the former pair of empirical/experimental variograms per time-slice are generated only if the **`---variogram_per_timeslice`** option is toggled. By default only the latter two pair of empirical/experimental variograms spanning the entire time-span are generated."
    ]
   },
   {


### PR DESCRIPTION
Updated to reflect recent changes from RAiDER PR#77 (https://github.com/dbekaert/RAiDER/pull/77), specifically ```-variogram_per_timeslice``` option now outlined and incorporated.

And narrative for Example #4 was fixed as it was copied over from another example by mistake.