### PR TITLE
Ensure consistency with bbox arguments

### DIFF
--- a/notebooks/raiderDownloadGNSS/raiderDownloadGNSS_tutorial.ipynb
+++ b/notebooks/raiderDownloadGNSS/raiderDownloadGNSS_tutorial.ipynb
@@ -163,7 +163,7 @@
     "hidden": true
    },
    "source": [
-    "#### Geographic bounding box (**`--BBOX BOUNDING_BOX`**)"
+    "#### Geographic bounding box (**`--bounding_box BOUNDING_BOX`**)"
    ]
   },
   {
@@ -172,8 +172,8 @@
     "hidden": true
    },
    "source": [
-    "An area of interest may be specified as `SNWE` coordinates using the **`--BBOX`** option. Coordinates should be specified as a space delimited string surrounded by quotes. This example below would restrict the query to stations over northern California:\n",
-    "**`--BBOX '36 40 -124 -119'`**\n",
+    "An area of interest may be specified as `SNWE` coordinates using the **`--bounding_box`** option. Coordinates should be specified as a space delimited string surrounded by quotes. This example below would restrict the query to stations over northern California:\n",
+    "**`--bounding_box '36 40 -124 -119'`**\n",
     "\n",
     "If no area of interest is specified, the entire global archive will be queried."
    ]
@@ -196,7 +196,7 @@
    "source": [
     "The query may be restricted to an apropri list of stations. To pass this list to the program, a text file containing a list of 4-char station IDs separated by newlines must be passed as an argument for the **`--station_file`** option.\n",
     "\n",
-    "If used in conjunction with the **`--BBOX`** option outlined above, then listed stations which fall outside of the specified geographic bounding box will be discarded.\n",
+    "If used in conjunction with the **`--bounding_box`** option outlined above, then listed stations which fall outside of the specified geographic bounding box will be discarded.\n",
     "\n",
     "As an example refer to the text-file below, which would be passed as so: **`--station_file support_docs/CA_subset.txt`**"
    ]
@@ -397,7 +397,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!raiderDownloadGNSS.py --out products --years '2018' --returntime '00:00:00' --BBOX '36 40 -124 -119'"
+    "!raiderDownloadGNSS.py --out products --years '2018' --returntime '00:00:00' --bounding_box '36 40 -124 -119'"
    ]
   },
   {
@@ -526,7 +526,7 @@
    "outputs": [],
    "source": [
     "!rm -rf products\n",
-    "!raiderDownloadGNSS.py --out products --years '2018,2019' --returntime '00:00:00' --BBOX '36 40 -124 -119' --cpus all"
+    "!raiderDownloadGNSS.py --out products --years '2018,2019' --returntime '00:00:00' --bounding_box '36 40 -124 -119' --cpus all"
    ]
   },
   {

--- a/notebooks/raiderStats/raiderStats_tutorial.ipynb
+++ b/notebooks/raiderStats/raiderStats_tutorial.ipynb
@@ -316,7 +316,7 @@
     "hidden": true
    },
    "source": [
-    "#### Geographic bounding box (**`--bbox BOUNDING_BOX`**)"
+    "#### Geographic bounding box (**`--bounding_box BOUNDING_BOX`**)"
    ]
   },
   {
@@ -325,8 +325,8 @@
     "hidden": true
    },
    "source": [
-    "An area of interest may be specified as `SNWE` coordinates using the **`--bbox`** option. Coordinates should be specified as a space delimited string surrounded by quotes. The common intersection between the user-specified spatial bounds and the spatial bounds computed from the station locations in the input file is then passed. This example below would restrict the analysis to stations over northern California:\n",
-    "**`--bbox '36 40 -124 -119'`**\n",
+    "An area of interest may be specified as `SNWE` coordinates using the **`--bounding_box`** option. Coordinates should be specified as a space delimited string surrounded by quotes. The common intersection between the user-specified spatial bounds and the spatial bounds computed from the station locations in the input file is then passed. This example below would restrict the analysis to stations over northern California:\n",
+    "**`--bounding_box '36 40 -124 -119'`**\n",
     "\n",
     "If no area of interest is specified, by default the spatial bounds computed from the station locations in the input file as passed."
    ]
@@ -782,7 +782,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!raiderDownloadGNSS.py --out products --years '2018,2019' --returntime '00:00:00' --BBOX '36 40 -124 -119' --cpus all"
+    "!raiderDownloadGNSS.py --out products --years '2018,2019' --returntime '00:00:00' --bounding_box '36 40 -124 -119' --cpus all"
    ]
   },
   {


### PR DESCRIPTION
Consistency of ```--bounding_box``` flag now ensured between stats programs. Contingent on merge of https://github.com/dbekaert/RAiDER/pull/102